### PR TITLE
Fix build warnings

### DIFF
--- a/src/CinderFreenect.cpp
+++ b/src/CinderFreenect.cpp
@@ -234,7 +234,7 @@ freenect_context* Kinect::getContext()
 	// ultimately this should be replaced with a call_once
 	lock_guard<mutex> contextLock( sContextMutex );
 	if( ! sContext ) {
-		if( freenect_init( &sContext, NULL ) < 0 );
+		if( freenect_init( &sContext, NULL ) < 0 )
 			; // throw ExcFailedFreenectInit(); // this seems to always fail
 		freenect_set_log_level( sContext, FREENECT_LOG_ERROR );
 	}

--- a/src/CinderFreenect.cpp
+++ b/src/CinderFreenect.cpp
@@ -37,7 +37,7 @@ freenect_context*	Kinect::sContext = 0;
 class ImageSourceKinectColor : public ImageSource {
   public:
 	ImageSourceKinectColor( uint8_t *buffer, shared_ptr<Kinect::Obj> ownerObj )
-		: ImageSource(), mData( buffer ), mOwnerObj( ownerObj )
+		: ImageSource(), mOwnerObj( ownerObj ), mData( buffer )
 	{
 		setSize( 640, 480 );
 		setColorModel( ImageIo::CM_RGB );
@@ -67,7 +67,7 @@ class ImageSourceKinectColor : public ImageSource {
 class ImageSourceKinectInfrared : public ImageSource {
   public:
 	ImageSourceKinectInfrared( uint8_t *buffer, shared_ptr<Kinect::Obj> ownerObj )
-		: ImageSource(), mData( buffer ), mOwnerObj( ownerObj )
+		: ImageSource(), mOwnerObj( ownerObj ), mData( buffer )
 	{
 		setSize( 640, 480 );
 		setColorModel( ImageIo::CM_GRAY );
@@ -98,7 +98,7 @@ class ImageSourceKinectInfrared : public ImageSource {
 class ImageSourceKinectDepth : public ImageSource {
   public:
 	ImageSourceKinectDepth( uint16_t *buffer, shared_ptr<Kinect::Obj> ownerObj )
-		: ImageSource(), mData( buffer ), mOwnerObj( ownerObj )
+		: ImageSource(), mOwnerObj( ownerObj ), mData( buffer )
 	{
 		setSize( 640, 480 );
 		setColorModel( ImageIo::CM_GRAY );
@@ -130,7 +130,7 @@ template<typename T>
 class KinectDataDeleter {
   public:
 	KinectDataDeleter( Kinect::Obj::BufferManager<T> *bufferMgr, shared_ptr<Kinect::Obj> ownerObj )
-		: mBufferMgr( bufferMgr ), mOwnerObj( ownerObj )
+		: mOwnerObj( ownerObj ), mBufferMgr( bufferMgr )
 	{}
 	
 	void operator()( T *data ) {
@@ -147,8 +147,9 @@ Kinect::Kinect( Device device )
 }
 
 Kinect::Obj::Obj( int deviceIndex, bool depthRegister )
-	: mShouldDie( false ), mNewVideoFrame( false ), mNewDepthFrame( false ), 
-		mColorBuffers( 640 * 480 * 3, this ), mDepthBuffers( 640 * 480, this ), mVideoInfrared( false )
+	: mColorBuffers( 640 * 480 * 3, this ), mDepthBuffers( 640 * 480, this ),
+		mShouldDie( false ), mVideoInfrared( false ),
+		mNewVideoFrame( false ), mNewDepthFrame( false )
 {
 	if( freenect_open_device( getContext(), &mDevice, deviceIndex ) < 0 )
 		throw ExcFailedOpenDevice();

--- a/src/CinderFreenect.h
+++ b/src/CinderFreenect.h
@@ -146,7 +146,7 @@ class Kinect {
 		template<typename T>
 		struct BufferManager {
 			BufferManager( size_t allocationSize, Obj *kinectObj )
-				: mAllocationSize( allocationSize ), mKinectObj( kinectObj ), mActiveBuffer( 0 )
+				: mKinectObj( kinectObj ), mAllocationSize( allocationSize ), mActiveBuffer( 0 )
 			{}
 			~BufferManager();
 			
@@ -158,7 +158,7 @@ class Kinect {
 
 			Obj						*mKinectObj;
 			size_t					mAllocationSize;
-			// map from pointer to reference count			
+			// map from pointer to reference count
 			std::map<T*,size_t>		mBuffers;
 			T						*mActiveBuffer;
 		};

--- a/src/freenect/cameras.c
+++ b/src/freenect/cameras.c
@@ -747,6 +747,7 @@ static int write_register(freenect_device *dev, uint16_t reg, uint16_t data)
 }
 
 // This function is here for completeness.  We don't actually use it for anything right now.
+#if 0   // cinder: silence unused function warning
 static uint16_t read_register(freenect_device *dev, uint16_t reg)
 {
 	freenect_context *ctx = dev->parent;
@@ -765,6 +766,7 @@ static uint16_t read_register(freenect_device *dev, uint16_t reg)
 
 	return reply[1];
 }
+#endif
 
 static int freenect_fetch_reg_info(freenect_device *dev)
 {


### PR DESCRIPTION
I was getting a Makefile-based build going, and I always like to turn on -Werror when possible to help keep things tidy. This just cleans up a few build warnings (using 'clang version 3.2 (tags/RELEASE_32/final)').

There appear to be several other similar warnings issued from the core cinder libs - if you have any interest in cleaning those as well, I can volunteer a bit of time to help scrub them :)
